### PR TITLE
Replace `parse{Object,Node,Tree}` with `internal.TraverseMap`

### DIFF
--- a/internal/traverse_map.go
+++ b/internal/traverse_map.go
@@ -1,0 +1,53 @@
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// TraverseMap recursively walks the given map, calling set for each value.
+// If the value is a slice, set is called for each element of the slice.
+// The keys of nested maps are joined with the given delimiter.
+func TraverseMap(m map[string]any, delimiter string, set func(name, value string) error) error {
+	return traverseMap("", m, delimiter, set)
+}
+
+func traverseMap(key string, val any, delimiter string, set func(name, value string) error) error {
+	switch v := val.(type) {
+	case string:
+		return set(key, v)
+	case json.Number:
+		return set(key, v.String())
+	case uint64:
+		return set(key, strconv.FormatUint(v, 10))
+	case int:
+		return set(key, strconv.Itoa(v))
+	case int64:
+		return set(key, strconv.FormatInt(v, 10))
+	case float64:
+		return set(key, strconv.FormatFloat(v, 'g', -1, 64))
+	case bool:
+		return set(key, strconv.FormatBool(v))
+	case nil:
+		return set(key, "")
+	case []any:
+		for _, v := range v {
+			if err := traverseMap(key, v, delimiter, set); err != nil {
+				return err
+			}
+		}
+	case map[string]any:
+		for k, v := range v {
+			if key != "" {
+				k = key + delimiter + k
+			}
+			if err := traverseMap(k, v, delimiter, set); err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("couldn't convert %q (type %T) to string", val, val)
+	}
+	return nil
+}

--- a/internal/traverse_map_test.go
+++ b/internal/traverse_map_test.go
@@ -1,0 +1,110 @@
+package internal_test
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/peterbourgon/ff/v3/internal"
+)
+
+func TestTraverseMap(t *testing.T) {
+	tests := []struct {
+		M     map[string]any
+		Delim string
+		Want  map[string]struct{}
+	}{
+		{ // single values
+			M: map[string]any{
+				"s":   "foo",
+				"i":   123,
+				"i64": int64(123),
+				"u":   uint64(123),
+				"f":   1.23,
+				"jn":  json.Number("123"),
+				"b":   true,
+				"nil": nil,
+			},
+			Delim: ".",
+			Want: map[string]struct{}{
+				"s:foo":   {},
+				"i:123":   {},
+				"i64:123": {},
+				"u:123":   {},
+				"f:1.23":  {},
+				"jn:123":  {},
+				"b:true":  {},
+				"nil:":    {},
+			},
+		},
+		{ // slices
+			M: map[string]any{
+				"is": []any{1, 2, 3},
+				"ss": []any{"a", "b", "c"},
+				"bs": []any{true, false},
+				"as": []any{"a", 1, true},
+			},
+			Want: map[string]struct{}{
+				"is:1":     {},
+				"is:2":     {},
+				"is:3":     {},
+				"ss:a":     {},
+				"ss:b":     {},
+				"ss:c":     {},
+				"bs:true":  {},
+				"bs:false": {},
+				"as:a":     {},
+				"as:1":     {},
+				"as:true":  {},
+			},
+		},
+		{ // nested maps
+			M: map[string]any{
+				"m": map[string]any{
+					"s": "foo",
+					"m2": map[string]any{
+						"i": 123,
+					},
+				},
+			},
+			Delim: ".",
+			Want: map[string]struct{}{
+				"m.s:foo":    {},
+				"m.m2.i:123": {},
+			},
+		},
+		{ // nested maps with "-" delimiter
+			M: map[string]any{
+				"m": map[string]any{
+					"s": "foo",
+					"m2": map[string]any{
+						"i": 123,
+					},
+				},
+			},
+			Delim: "-",
+			Want: map[string]struct{}{
+				"m-s:foo":    {},
+				"m-m2-i:123": {},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			// deleteSet deletes the key from test.WantSet if it exists.
+			deleteSet := func(name, value string) error {
+				key := name + ":" + value
+				delete(test.Want, key)
+				return nil
+			}
+
+			if err := internal.TraverseMap(test.M, test.Delim, deleteSet); err != nil {
+				t.Fatal(err)
+			}
+			if len(test.Want) > 0 {
+				t.Fatalf("Failed to match keys: %v", test.Want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The logic of `ff.parseObject`, `ffyaml.parseNode`, and `fftoml.parseTree` is redundant. Every decoder just generates the same map that need to be walked. 